### PR TITLE
fix : 아이템 중복 삭제 버그 수정

### DIFF
--- a/src/Field.cpp
+++ b/src/Field.cpp
@@ -429,6 +429,14 @@ void psh::Field::AddActor(const shared<GameObject>& obj)
 // 오브젝트 삭제 대기 목록에 추가
 void psh::Field::DestroyActor(shared<GameObject>& obj)
 {
+    if (obj->Valid() == false)
+    {
+        _logger->Write(L"DoubleDelete", CLogger::LogLevel::Invalid
+                       , L"DoubleDelete. type : %d, remove reason : %d, templateID : %d, field : %d"
+                       , obj->ObjectType(), obj->RemoveReason(), obj->TemplateId(), _groupType);
+        return;
+    }
+
     obj->Valid(false);
     _delWaits.emplace_back(obj);
 }
@@ -510,7 +518,10 @@ void psh::Field::UpdateContent(const int deltaMs)
     OPTICK_EVENT();
     for (auto& obj : _objects)
     {
-        obj->Update(deltaMs);
+        if (obj->Valid())
+        {
+            obj->Update(deltaMs);
+        }
     }
 }
 

--- a/src/RangeObject.cpp
+++ b/src/RangeObject.cpp
@@ -110,7 +110,7 @@ void psh::Item::OnUpdate(int delta)
     SingleInteractionObject::OnUpdate(delta);
     _life.Update(delta);
 
-    if (_life.IsExpired())
+    if (_life.IsExpired() && Valid())
     {
         _field.DestroyActor(shared_from_this());
     }


### PR DESCRIPTION
## 문제 설명

아이템이 삭제되었다는 패킷이 두 번 옴

## 원인 분석

- 부모 클래스에서 충돌 시 삭제 요청 -> 자식 update에서 소멸 처리
- 두 행동이 한 프레임에 발생할 경우 두 번 삭제 요청
- OnDestroy가 두 번 호출되어 삭제 패킷 전송됨

## 해결 방법

- DestroyActor 내부에서 valid 체크 진행. 중복 삭제 발생시 로깅
- 아이템 update 내부에서 valid 체크 진행

## 테스트 방법

- 플레이어 위치에 수명이 0인 아이템 생성 시키고 두 번 삭제 문제가 발생하는지 확인
- 항상 발생하는 것을 확인

## 추가 참고 사항

근본적인 구조 변경이 필요해 보임

---

## 원인 분석 과정
- 문제 발생 후 서버 덤프
- 아이템 map의 아이템 수가 음수인 것을 확인
  - 삭제 로직에서만 해당 카운트를 건드림
- 아이템 Destroy 쪽 코드 보고 문제 발생 가능성 확인